### PR TITLE
Split up build and query args for faiss-ivf

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -26,8 +26,8 @@ float:
       base-args: ["@metric"]
       run-groups:
         base:
-          args: [[5, 10, 20, 50, 100, 200, 400, 800, 1000],
-                 [1, 2, 3, 4, 5, 8, 10, 20, 50, 100, 200]]
+          args: [[5, 10, 20, 50, 100, 200, 400, 800, 1000]]
+          query-args: [[1, 2, 3, 4, 5, 8, 10, 20, 50, 100, 200]]
     flann:
       docker-tag: ann-benchmarks-flann
       module: ann_benchmarks.algorithms.flann

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -57,6 +57,7 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count=3, fo
         elif algo.use_threads() and not force_single:
             pool = multiprocessing.pool.ThreadPool()
             results = pool.map(single_query, X_test)
+            pool.close()
         else:
             results = [single_query(x) for x in X_test]
 


### PR DESCRIPTION
This adds support for the new build and query args separation for FAISS.