### PR TITLE
Correctly set number of probes in FAISS.

### DIFF
--- a/ann_benchmarks/algorithms/faiss.py
+++ b/ann_benchmarks/algorithms/faiss.py
@@ -57,7 +57,7 @@ class FaissIVF(BaseANN):
 
     def set_query_arguments(self, n_probe):
         self._n_probe = n_probe
-        self._index.n_probe = self._n_probe
+        self._index.nprobe = self._n_probe
 
     def query(self, v, n):
         if self._metric == 'angular':


### PR DESCRIPTION
Fix for a bug introduced in #2 (number of probes wasn't set correctly). 